### PR TITLE
Download cmake from github mirror, not from the cmake website. 

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,7 +5,6 @@ basedir = dirname(@__FILE__)
 prefix = joinpath(basedir, "usr")
 
 cmake_version = v"3.12.3"
-
 base_url = "https://github.com/Kitware/CMake/releases/download/v$(cmake_version)"
 @static if Sys.iswindows()
     binary_name = "cmake.exe"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,7 +5,8 @@ basedir = dirname(@__FILE__)
 prefix = joinpath(basedir, "usr")
 
 cmake_version = v"3.12.3"
-base_url = "https://cmake.org/files/v$(cmake_version.major).$(cmake_version.minor)"
+
+base_url = "https://github.com/Kitware/CMake/releases/download/v$(cmake_version)"
 @static if Sys.iswindows()
     binary_name = "cmake.exe"
 else


### PR DESCRIPTION
Related to this [issue](https://github.com/JuliaPackaging/CMake.jl/issues/12). Cmake is moving offices today and [their servers are down](http://prntscr.com/lve51m). As a result cmake.jl fails. 

It's a good idea to download the source from github as opposed to their website.