### PR TITLE
Add cirrus (freebsd) and drone (arm) CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,18 @@
+freebsd_instance:
+  image: freebsd-12-0-release-amd64
+task:
+  name: FreeBSD
+  env:
+    matrix:
+      - JULIA_VERSION: 1.0
+      - JULIA_VERSION: 1.1
+      - JULIA_VERSION: 1.2
+      - JULIA_VERSION: nightly
+  install_script:
+    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+  build_script:
+    - cirrusjl build
+  test_script:
+    - cirrusjl test
+  coverage_script:
+    - cirrusjl coverage codecov coveralls

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,4 +15,4 @@ task:
   test_script:
     - cirrusjl test
   coverage_script:
-    - cirrusjl coverage codecov coveralls
+    - cirrusjl coverage codecov coveralls 

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ steps:
   image: julia:1.0
   commands:
       - uname -a
-      - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("CMake"); Pkg.test("CMake"; coverage=true)'
+      - julia --project=. -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
 --- 
 
@@ -26,7 +26,7 @@ steps:
   image: julia:1.1
   commands:
       - uname -a
-      - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("CMake"); Pkg.test("CMake"; coverage=true)'
+      - julia --project=. -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
 ---
 
@@ -42,7 +42,7 @@ steps:
   image: julia:1.0
   commands:
       - uname -a
-      - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("CMake"); Pkg.test("CMake"; coverage=true)'
+      - julia --project=. -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
 ---
 
@@ -58,4 +58,4 @@ steps:
   image: julia:1.1
   commands:
       - uname -a
-      - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("CMake"); Pkg.test("CMake"; coverage=true)'
+      - julia --project=. -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,6 +10,7 @@ steps:
   image: julia:1.0
   commands:
       - uname -a
+      - apt-get update && apt-get install -qy build-essential
       - julia --project=. -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
 --- 
@@ -26,6 +27,7 @@ steps:
   image: julia:1.1
   commands:
       - uname -a
+      - apt-get update && apt-get install -qy build-essential
       - julia --project=. -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
 ---
@@ -42,6 +44,7 @@ steps:
   image: julia:1.0
   commands:
       - uname -a
+      - apt-get update && apt-get install -qy build-essential
       - julia --project=. -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
 ---
@@ -58,4 +61,5 @@ steps:
   image: julia:1.1
   commands:
       - uname -a
+      - apt-get update && apt-get install -qy build-essential
       - julia --project=. -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,61 @@
+kind: pipeline
+name: linux-arm-1.0
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
+- name: build
+  image: julia:1.0
+  commands:
+      - uname -a
+      - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("CMake"); Pkg.test("CMake"; coverage=true)'
+
+--- 
+
+kind: pipeline
+name: linux-arm-1.1
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
+- name: build
+  image: julia:1.1
+  commands:
+      - uname -a
+      - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("CMake"); Pkg.test("CMake"; coverage=true)'
+
+---
+
+kind: pipeline
+name: linux-aarch64-1.0
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: julia:1.0
+  commands:
+      - uname -a
+      - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("CMake"); Pkg.test("CMake"; coverage=true)'
+
+---
+
+kind: pipeline
+name: linux-aarch64-1.1
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: julia:1.1
+  commands:
+      - uname -a
+      - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("CMake"); Pkg.test("CMake"; coverage=true)'


### PR DESCRIPTION
I'm having problems building CMake on arm (as a dep of JLD.jl) and I noticed some discussion about freebsd, so I thought I'd add them both for CI testing

Enable cirrus for freebsd: https://github.com/marketplace/cirrus-ci
Enable drone for arm: https://drone.io/ 