### PR TITLE
Bump CMake version to 3.15.3

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,7 +4,7 @@ using BinDeps: MakeTargets
 basedir = dirname(@__FILE__)
 prefix = joinpath(basedir, "usr")
 
-cmake_version = v"3.12.3"
+cmake_version = v"3.15.3"
 base_url = "https://github.com/Kitware/CMake/releases/download/v$(cmake_version)"
 @static if Sys.iswindows()
     binary_name = "cmake.exe"


### PR DESCRIPTION
https://cmake.org/cmake/help/v3.15/release/3.15.html

-- 
I ran into a CUDA compilation issue with CMake 3.12.3 (current version in this repo).

I tested CMake 3.10.2 and CMake 3.15.3. 
Both of them work fine for me.